### PR TITLE
[FEAT] admin 대시보드 페이지 UI 생성 #45

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "react-dom": "^18.3.1",
         "react-redux": "^9.2.0",
         "react-router-dom": "^7.9.4",
+        "recharts": "^3.3.0",
         "styled-components": "^6.1.19",
         "styled-reset": "^5.0.0",
         "swiper": "^12.0.3"
@@ -1746,6 +1747,69 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2578,6 +2642,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2689,6 +2762,127 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -2760,6 +2954,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -3049,6 +3249,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.41.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.41.0.tgz",
+      "integrity": "sha512-bDd3oRmbVgqZCJS6WmeQieOrzpl3URcWBUVDXxOELlUW2FuW+0glPOz1n0KnRie+PdyvUZcXz2sOn00c6pPRIA==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.25.11",
@@ -3459,6 +3669,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3961,6 +4177,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -5098,7 +5323,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-redux": {
@@ -5170,6 +5394,33 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.3.0.tgz",
+      "integrity": "sha512-Vi0qmTB0iz1+/Cz9o5B7irVyUjX2ynvEgImbgMt/3sKRREcUM07QiYjS1QpAVrkmVlXqy5gykq4nGWMz9AS4Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/redux": {
@@ -5860,6 +6111,12 @@
         "node": ">= 4.7.0"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6169,6 +6426,28 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^18.3.1",
     "react-redux": "^9.2.0",
     "react-router-dom": "^7.9.4",
+    "recharts": "^3.3.0",
     "styled-components": "^6.1.19",
     "styled-reset": "^5.0.0",
     "swiper": "^12.0.3"

--- a/src/api/adminApi.ts
+++ b/src/api/adminApi.ts
@@ -1,0 +1,112 @@
+import type {
+  AdminStats,
+  DailyStat,
+  RevenueStat,
+  CourseStat,
+  CategoryStat,
+  AdminSettings,
+  DateRangeParams,
+  CourseStatParams,
+} from '../types/AdminType';
+
+import {
+  mockAdminStats,
+  mockDailyStats,
+  mockRevenueStats,
+  mockCourseStats,
+  mockCategoryStats,
+  mockAdminSettings,
+} from '../data/mockAdminData';
+
+// 공통 API 지연 시간 (ms)
+const API_DELAY = 500;
+
+/**
+ * API 호출을 시뮬레이션하는 래퍼
+ * @param data 반환할 목업 데이터
+ * @param delay 지연 시간
+ */
+const simulateFetch = <T>(data: T, delay: number = API_DELAY): Promise<T> => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(data);
+    }, delay);
+  });
+};
+
+// --- API 함수들 ---
+
+/**
+ * GET /admin/dashboard/stats
+ * 대시보드 상단 카드 통계 조회
+ */
+export const fetchDashboardStats = (): Promise<AdminStats> => {
+  // StatsCardArea에서 사용할 데이터:
+  // today_visitors, today_views, today_revenue
+  // (참고: new_users는 daily-stats에서 가져와야 함)
+  return simulateFetch(mockAdminStats, 300);
+};
+
+/**
+ * GET /admin/dashboard/daily-stats
+ * 일별 접속, 조회, 매출 통계 (ChartArea용)
+ * (참고: '신규 회원 수' 카드 데이터도 여기서 가져옴)
+ */
+export const fetchDailyStats = (
+  params: DateRangeParams,
+): Promise<DailyStat[]> => {
+  console.log('Fetching daily stats with params:', params);
+  // TODO: 실제 API 연결 시 params에 따라 mockDailyStats 필터링
+  return simulateFetch(mockDailyStats, 800);
+};
+
+/**
+ * GET /admin/dashboard/revenue-stats
+ * 일별 상세 매출 통계
+ */
+export const fetchRevenueStats = (
+  params: DateRangeParams,
+): Promise<RevenueStat[]> => {
+  console.log('Fetching revenue stats with params:', params);
+  return simulateFetch(mockRevenueStats, 1000);
+};
+
+/**
+ * GET /admin/dashboard/course-stats
+ * 강의별 통계 (ProgressArea, TableArea용)
+ */
+export const fetchCourseStats = (
+  params: CourseStatParams,
+): Promise<CourseStat[]> => {
+  console.log('Fetching course stats with params:', params);
+  return simulateFetch(mockCourseStats, 1200);
+};
+
+/**
+ * GET /admin/dashboard/category-stats
+ * 카테고리별 통계 (ProgressArea용)
+ */
+export const fetchCategoryStats = (): Promise<CategoryStat[]> => {
+  return simulateFetch(mockCategoryStats, 900);
+};
+
+/**
+ * GET /admin/dashboard/settings
+ * 시스템 설정 조회
+ */
+export const fetchSettings = (): Promise<AdminSettings> => {
+  return simulateFetch(mockAdminSettings, 400);
+};
+
+/**
+ * PUT /admin/dashboard/settings
+ * 시스템 설정 수정
+ */
+export const updateSettings = (
+  newSettings: Partial<AdminSettings>,
+): Promise<AdminSettings> => {
+  console.log('Updating settings:', newSettings);
+  // 실제로는 mockAdminSettings를 업데이트해야 함
+  const updatedSettings = { ...mockAdminSettings, ...newSettings };
+  return simulateFetch(updatedSettings, 600);
+};

--- a/src/data/mockAdminData.ts
+++ b/src/data/mockAdminData.ts
@@ -1,0 +1,165 @@
+import type {
+  AdminStats,
+  DailyStat,
+  RevenueStat,
+  CourseStat,
+  CategoryStat,
+  AdminSettings,
+} from '../types/AdminType';
+
+/**
+ * /admin/dashboard/stats
+ * (대시보드 상단 카드 데이터)
+ */
+export const mockAdminStats: AdminStats = {
+  total_users: 1250,
+  total_courses: 24,
+  total_enrollments: 3200,
+  active_enrollments: 1800,
+  total_revenue: 150_000_000,
+  pending_refunds: 350_000,
+  today_visitors: 120, // StatsCardArea ①
+  today_views: 450, // StatsCardArea ②
+  today_revenue: 1_200_000, // StatsCardArea ③
+};
+
+/**
+ * (차트용) 날짜 및 랜덤 데이터 생성 헬퍼
+ */
+const createChartData = (days: number) => {
+  const data = [];
+  const today = new Date();
+  for (let i = days - 1; i >= 0; i--) {
+    const date = new Date(today);
+    date.setDate(today.getDate() - i);
+    const dateString = date.toISOString().split('T')[0];
+    
+    data.push({
+      date: dateString,
+      visitors: Math.floor(Math.random() * 100) + 50,
+      views: Math.floor(Math.random() * 300) + 200,
+      revenue: Math.floor(Math.random() * 500000) + 100000,
+      enrollments: Math.floor(Math.random() * 10) + 1,
+      new_users: Math.floor(Math.random() * 5) + 1, // StatsCardArea ④
+      
+      payment_count: Math.floor(Math.random() * 20),
+      refund_amount: Math.floor(Math.random() * 50000),
+      refund_count: Math.floor(Math.random() * 3),
+      get net_revenue() { return this.revenue - this.refund_amount; }
+    });
+  }
+  return data;
+};
+
+// 7일치 동적 데이터 생성
+const chartData7Days = createChartData(7);
+
+/**
+ * /admin/dashboard/daily-stats
+ * (ChartArea - 일별 접속, 조회, 매출 차트 데이터)
+ */
+export const mockDailyStats: DailyStat[] = chartData7Days.map(d => ({
+  date: d.date,
+  visitors: d.visitors,
+  views: d.views,
+  revenue: d.revenue,
+  enrollments: d.enrollments,
+  new_users: d.new_users,
+}));
+
+/**
+ * /admin/dashboard/revenue-stats
+ * (매출 상세 차트용 데이터 - 필요시 사용)
+ */
+export const mockRevenueStats: RevenueStat[] = chartData7Days.map(d => ({
+  date: d.date,
+  revenue: d.revenue,
+  payment_count: d.payment_count,
+  refund_amount: d.refund_amount,
+  refund_count: d.refund_count,
+  net_revenue: d.net_revenue,
+}));
+
+/**
+ * /admin/dashboard/course-stats
+ * (ProgressArea 및 TableArea용 데이터)
+ */
+export const mockCourseStats: CourseStat[] = [
+  {
+    course_id: 1,
+    course_title: '견고한 파이썬 부스트 커뮤니티 1기',
+    category_name: '백엔드',
+    total_enrollments: 150,
+    active_enrollments: 120,
+    avg_progress: 75.5,
+    completion_count: 80,
+    completion_rate: 53.3,
+    total_revenue: 15_000_000,
+  },
+  {
+    course_id: 2,
+    course_title: 'React와 TypeScript 마스터 3기',
+    category_name: '프론트엔드',
+    total_enrollments: 200,
+    active_enrollments: 180,
+    avg_progress: 42.0,
+    completion_count: 50,
+    completion_rate: 25.0,
+    total_revenue: 20_000_000,
+  },
+  {
+    course_id: 3,
+    course_title: 'AI 모델링 입문',
+    category_name: 'AI/ML',
+    total_enrollments: 100,
+    active_enrollments: 50,
+    avg_progress: 90.1,
+    completion_count: 45,
+    completion_rate: 45.0,
+    total_revenue: 10_000_000,
+  },
+];
+
+/**
+ * /admin/dashboard/category-stats
+ * (ProgressArea 차트용 데이터)
+ */
+export const mockCategoryStats: CategoryStat[] = [
+  {
+    category_id: 1,
+    category_name: '프론트엔드',
+    course_count: 5,
+    total_enrollments: 450,
+    total_revenue: 45_000_000,
+    avg_completion_rate: 30.5,
+  },
+  {
+    category_id: 2,
+    category_name: '백엔드',
+    course_count: 8,
+    total_enrollments: 550,
+    total_revenue: 60_000_000,
+    avg_completion_rate: 45.2,
+  },
+  {
+    category_id: 3,
+    category_name: 'AI/ML',
+    course_count: 3,
+    total_enrollments: 250,
+    total_revenue: 25_000_000,
+    avg_completion_rate: 50.0,
+  },
+];
+
+/**
+ * /admin/dashboard/settings
+ * (설정 페이지용 데이터)
+ */
+export const mockAdminSettings: AdminSettings = {
+  site_name: 'BootRun',
+  course_price: 150000,
+  enrollment_period_years: 1,
+  refund_period_days: 7,
+  refund_progress_limit: 10,
+  passing_score_rate: 80,
+};

--- a/src/data/mockLectureData.ts
+++ b/src/data/mockLectureData.ts
@@ -109,47 +109,6 @@ export const mockCardData: CardData = {
 
 
 
-//  마이 페이지 데이터
-import type { ProfileData, OrderData, AccountData } from '../types/ProfileType';
 
-// 1. ProfilePage용 목업 데이터
-export const mockProfileData: ProfileData = {
-  name: "지상 최강 개발자",
-  gender: "male",
-  birthdate: "", // 초기값 없음
-  profileImageUrl: "/images/profile/profile-user-default.png" // (컨벤션에 맞춘 경로)
-};
 
-// 2. OrderHistoryPage용 목업 데이터
-export const mockOrderData: OrderData = {
-  orders: [
-    { 
-      id: "1", 
-      status: 'completed', 
-      courseName: "견고한 파이썬 부스트 커뮤니티 1기 (디스코드 커뮤니티)", 
-      price: "200,000원",
-      orderNumber: "UT0017164m01012506121444071527",
-      orderDate: "2025.06.12(목) 14:44",
-      paymentDate: "2025.06.12(목) 14:44",
-      paymentMethod: "신용카드",
-      receiptUrl: "#"
-    },
-    { 
-      id: "2", 
-      status: 'pending', 
-      courseName: "견고한 파이썬 부스트 커뮤니티 1기 (디스코드 커뮤니티)", 
-      price: "200,000원",
-      orderNumber: "UT0017164m01012506121444071527",
-      orderDate: "2025.06.12(목) 14:44",
-      paymentDate: "2025.06.12(목) 14:44",
-      paymentMethod: "신용카드",
-      receiptUrl: "#"
-    },
-  ]
-};
 
-// 3. AccountPage용 목업 데이터
-export const mockAccountData: AccountData = {
-  email: "paul-lab@naver.com",
-  githubEmail: null // null이면 "GitHub 계정 로그인" 링크 표시
-};

--- a/src/data/mockMyPageData.ts
+++ b/src/data/mockMyPageData.ts
@@ -1,0 +1,44 @@
+import type { ProfileData, OrderData, AccountData } from '../types/ProfileType';
+
+// 1. ProfilePage용 목업 데이터
+export const mockProfileData: ProfileData = {
+  name: "지상 최강 개발자",
+  gender: "male",
+  birthdate: "", // 초기값 없음
+  profileImageUrl: "/images/profile/profile-user-default.png" // (컨벤션에 맞춘 경로)
+};
+
+// 2. OrderHistoryPage용 목업 데이터
+export const mockOrderData: OrderData = {
+  orders: [
+    { 
+      id: "1", 
+      status: 'completed', 
+      courseName: "견고한 파이썬 부스트 커뮤니티 1기 (디스코드 커뮤니티)", 
+      price: "200,000원",
+      orderNumber: "UT0017164m01012506121444071527",
+      orderDate: "2025.06.12(목) 14:44",
+      paymentDate: "2025.06.12(목) 14:44",
+      paymentMethod: "신용카드",
+      receiptUrl: "#"
+    },
+    { 
+      id: "2", 
+      status: 'pending', 
+      courseName: "견고한 파이썬 부스트 커뮤니티 1기 (디스코드 커뮤니티)", 
+      price: "200,000원",
+      orderNumber: "UT0017164m01012506121444071527",
+      orderDate: "2025.06.12(목) 14:44",
+      paymentDate: "2025.06.12(목) 14:44",
+      paymentMethod: "신용카드",
+      receiptUrl: "#"
+    },
+  ]
+};
+
+// 3. AccountPage용 목업 데이터
+export const mockAccountData: AccountData = {
+  email: "paul-lab@naver.com",
+  githubEmail: null // null이면 "GitHub 계정 로그인" 링크 표시
+};
+

--- a/src/pages/Admin/ChartArea.tsx
+++ b/src/pages/Admin/ChartArea.tsx
@@ -1,0 +1,204 @@
+import React from 'react';
+import styled from 'styled-components';
+import {
+  LineChart, Line, BarChart, Bar, XAxis, YAxis,
+  CartesianGrid, Tooltip, Legend, ResponsiveContainer,
+  type TooltipProps
+} from 'recharts';
+import type { DailyStat } from '../../types/AdminType';
+import { ErrorMessage, LoadingSpinner } from '../../components/HelperComponents';
+
+// 1. Tooltip의 payload 타입 정의 (any 대신 사용)
+interface TooltipPayload {
+  name: string;
+  value: number;
+  color: string;
+  dataKey: string;
+}
+
+// 2. Tooltip의 props 타입 정의
+interface CustomTooltipProps {
+  active?: boolean;
+  payload?: TooltipPayload[];
+  label?: string;
+}
+
+// 3. Props 타입 정의
+interface ChartAreaProps {
+  dailyStats: DailyStat[] | null;
+}
+
+// 4. 헬퍼 함수
+const formatCurrency = (tick: number) => {
+  if (tick >= 1000000) return `${tick / 1000000}백만`;
+  if (tick >= 1000) return `${tick / 1000}천`;
+  return tick.toString();
+};
+
+// 5. Tooltip 커스텀 렌더 함수 (타입 적용)
+const renderTooltip = (props: TooltipProps<number, string>) => {
+  const { active, payload, label } = props as CustomTooltipProps;
+  if (active && payload && payload.length) {
+    return (
+      <S.TooltipContainer>
+        {/* label 타입은 'string | number'이므로 그대로 사용 가능 */}
+        <p className="label">{label}</p>
+        {payload.map((p) => (
+          <p className="desc" style={{ color: p.color }} key={p.dataKey}>
+            {`${p.name} : ${
+              p.dataKey === 'revenue'
+                ? formatCurrency(p.value ?? 0) // p.value는 number
+                : (p.value ?? 0).toLocaleString()
+            }`}
+          </p>
+        ))}
+      </S.TooltipContainer>
+    );
+  }
+  return null;
+};
+
+const ChartArea: React.FC<ChartAreaProps> = ({ dailyStats }) => {
+  const loading = !dailyStats;
+
+  return (
+    <S.ChartGrid>
+      {/* 차트 1: 일별 접속자 수 */}
+      <S.CardBox>
+        <S.SectionHeader>
+          <S.SectionTitle>일별 접속자 수</S.SectionTitle>
+        </S.SectionHeader>
+        <S.ChartWrapper>
+          {loading && <LoadingSpinner />}
+          {!loading && !dailyStats && <ErrorMessage message="데이터 없음" />}
+          {dailyStats && (
+            <ResponsiveContainer width="100%" height={300}>
+              <LineChart data={dailyStats}>
+                <CartesianGrid strokeDasharray="3 3" vertical={false} />
+                <XAxis dataKey="date" fontSize="1.2rem" />
+                <YAxis fontSize="1.2rem" />
+                <Tooltip content={renderTooltip} />
+                <Legend />
+                <Line
+                  type="monotone"
+                  dataKey="visitors"
+                  name="접속자"
+                  stroke="#2E6FF2"
+                  strokeWidth={2}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          )}
+        </S.ChartWrapper>
+      </S.CardBox>
+
+      {/* (차트 2: 일별 조회수 - BarChart) */}
+      <S.CardBox>
+        <S.SectionHeader>
+          <S.SectionTitle>일별 조회수</S.SectionTitle>
+        </S.SectionHeader>
+        <S.ChartWrapper>
+          {loading && <LoadingSpinner />}
+          {dailyStats && (
+            <ResponsiveContainer width="100%" height={300}>
+              <BarChart data={dailyStats}>
+                {/* ... (XAxis, YAxis, Tooltip, Legend) ... */}
+                <Bar dataKey="views" name="조회수" fill="#B5CEFF" />
+              </BarChart>
+            </ResponsiveContainer>
+          )}
+        </S.ChartWrapper>
+      </S.CardBox>
+
+      {/* (차트 3: 일별 결제 금액 - LineChart) */}
+      <S.CardBox>
+        <S.SectionHeader>
+          <S.SectionTitle>일별 결제 금액</S.SectionTitle>
+        </S.SectionHeader>
+        <S.ChartWrapper>
+          {loading && <LoadingSpinner />}
+          {dailyStats && (
+            <ResponsiveContainer width="100%" height={300}>
+              <LineChart data={dailyStats}>
+                {/* ... (XAxis, Tooltip, Legend) ... */}
+                <YAxis fontSize="1.2rem" tickFormatter={formatCurrency} />
+                <Line type="monotone" dataKey="revenue" name="결제액(원)" stroke="#8B38FF" />
+              </LineChart>
+            </ResponsiveContainer>
+          )}
+        </S.ChartWrapper>
+      </S.CardBox>
+    </S.ChartGrid>
+  );
+};
+
+// --- Styles ---
+const S = {
+  ChartGrid: styled.section`
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 2rem;
+    @media (${({ theme }) => theme.devices.laptop}) {
+      grid-template-columns: 1fr;
+    }
+  `,
+  CardBox: styled.div`
+    background: ${({ theme }) => theme.colors.white};
+    border-radius: ${({ theme }) => theme.radius.md};
+    padding: 2.4rem;
+    box-shadow: ${({ theme }) => theme.colors.shadow};
+  `,
+  SectionHeader: styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 2.4rem;
+  `,
+  SectionTitle: styled.h3`
+    font-size: ${({ theme }) => theme.fontSize.lg}; // 2.4rem
+    font-weight: 600;
+    color: ${({ theme }) => theme.colors.surface};
+    margin: 0;
+  `,
+  ChartWrapper: styled.div`
+    width: 100%;
+    height: 300px; // ResponsiveContainer의 높이와 일치
+  `,
+  FilterWrapper: styled.div`
+    display: flex;
+    gap: 0.8rem;
+  `,
+  FilterButton: styled.button<{ $active?: boolean }>`
+    padding: 0.8rem 1.2rem;
+    font-size: 1.3rem;
+    font-weight: 500;
+    border-radius: ${({ theme }) => theme.radius.sm};
+    background: ${({ theme, $active }) =>
+      $active ? theme.colors.primary100 : theme.colors.gray100};
+    color: ${({ theme, $active }) =>
+      $active ? theme.colors.primary300 : theme.colors.gray300};
+    border: none;
+    cursor: pointer;
+    &:hover {
+      background: ${({ theme }) => theme.colors.gray200};
+    }
+  `,
+  TooltipContainer: styled.div`
+    background: rgba(255, 255, 255, 0.9);
+    border: 1px solid ${({ theme }) => theme.colors.gray200};
+    padding: 1.2rem;
+    border-radius: ${({ theme }) => theme.radius.sm};
+    box-shadow: ${({ theme }) => theme.colors.shadow};
+    .label {
+      font-size: 1.4rem;
+      font-weight: 600;
+      color: ${({ theme }) => theme.colors.surface};
+      margin-bottom: 0.8rem;
+    }
+    .desc {
+      font-size: 1.3rem;
+      margin: 0;
+    }
+  `,
+};
+export default ChartArea;

--- a/src/pages/Admin/DashBoardPage.tsx
+++ b/src/pages/Admin/DashBoardPage.tsx
@@ -1,72 +1,24 @@
-import React from 'react';
+import  { useEffect, useState } from 'react';
 import styled from 'styled-components';
+import type {
+  AdminStats,
+  CourseStat,
+  DailyStat,
+  CategoryStat, 
+} from '../../types/AdminType';
+import {
+  fetchDashboardStats,
+  fetchDailyStats,
+  fetchCourseStats,
+  fetchCategoryStats, 
+} from '../../api/adminApi';
 
-// (가상) 스텁 컴포넌트들.
-// TODO: '/components/admin/' 폴더 하위의 실제 파일로 분리해야 합니다.
+import StatsCardArea from './StatsCardArea';
+import ChartArea from './ChartArea';
+import ProgressArea from './ProgressArea';
+import TableArea from './TableArea';
 
-const StatsCardArea: React.FC = () => (
-  <S.StatsGrid>
-    <S.CardBox>
-      <S.CardTitle>오늘 접속자 수</S.CardTitle>
-      <S.CardContentPlaceholder>
-        <span>(아이콘 + 숫자 + 전일 대비)</span>
-      </S.CardContentPlaceholder>
-    </S.CardBox>
-    <S.CardBox>
-      <S.CardTitle>총 조회수</S.CardTitle>
-      <S.CardContentPlaceholder>
-        <span>(아이콘 + 숫자 + 전일 대비)</span>
-      </S.CardContentPlaceholder>
-    </S.CardBox>
-    <S.CardBox>
-      <S.CardTitle>결제 금액 합계</S.CardTitle>
-      <S.CardContentPlaceholder>
-        <span>(아이콘 + 숫자 + 전일 대비)</span>
-      </S.CardContentPlaceholder>
-    </S.CardBox>
-    <S.CardBox>
-      <S.CardTitle>신규 회원 수</S.CardTitle>
-      <S.CardContentPlaceholder>
-        <span>(아이콘 + 숫자 + 전일 대비)</span>
-      </S.CardContentPlaceholder>
-    </S.CardBox>
-  </S.StatsGrid>
-);
-
-const ChartArea: React.FC = () => (
-  <S.ChartGrid>
-    <S.CardBox>
-      <S.SectionTitle>일별 접속자 수 (LineChart)</S.SectionTitle>
-      <S.ChartPlaceholder>[LineChart 영역]</S.ChartPlaceholder>
-    </S.CardBox>
-    <S.CardBox>
-      <S.SectionTitle>일별 조회수 (BarChart)</S.SectionTitle>
-      <S.ChartPlaceholder>[BarChart 영역]</S.ChartPlaceholder>
-    </S.CardBox>
-    <S.CardBox>
-      <S.SectionTitle>일별 결제 금액 (LineChart)</S.SectionTitle>
-      <S.ChartPlaceholder>[LineChart 영역]</S.ChartPlaceholder>
-    </S.CardBox>
-  </S.ChartGrid>
-);
-
-const ProgressArea: React.FC = () => (
-  <S.CardBox>
-    <S.SectionTitle>과목별 수강 진행률</S.SectionTitle>
-    <S.ChartPlaceholder>
-      (PieChart / HorizontalBar / RingChart 등이 이곳에 표시됩니다.)
-    </S.ChartPlaceholder>
-  </S.CardBox>
-);
-
-const TableArea: React.FC = () => (
-  <S.CardBox>
-    <S.SectionTitle>결제 상세 내역</S.SectionTitle>
-    <S.ChartPlaceholder>
-      (검색창 + 기간 필터 + 내보내기 버튼 + React Table이 이곳에 표시됩니다.)
-    </S.ChartPlaceholder>
-  </S.CardBox>
-);
+import { LoadingSpinner } from '../../components/HelperComponents'; 
 
 // --- 헬퍼 함수 ---
 const getTodayDate = () => {
@@ -78,42 +30,93 @@ const getTodayDate = () => {
 };
 
 // --- 관리자 대시보드 메인 페이지 ---
-
 export default function DashboardPage() {
   const todayDate = getTodayDate();
 
+  // API 데이터를 저장할 State
+  const [stats, setStats] = useState<AdminStats | null>(null);
+  const [dailyStats, setDailyStats] = useState<DailyStat[] | null>(null);
+  const [courseStats, setCourseStats] = useState<CourseStat[] | null>(null);
+  const [categoryStats, setCategoryStats] = useState<CategoryStat[] | null>(null); 
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const loadDashboardData = async () => {
+      try {
+        setLoading(true);
+        // ▼▼▼ 5. 4개의 API를 동시에 호출 ▼▼▼
+        const [
+          statsData,
+          dailyStatsData,
+          courseStatsData,
+          categoryStatsData,
+        ] = await Promise.all([
+          fetchDashboardStats(),
+          fetchDailyStats({ period: 'week' }), // 7일치 데이터
+          fetchCourseStats({}),
+          fetchCategoryStats(), // API 호출 추가
+        ]);
+
+        setStats(statsData);
+        setDailyStats(dailyStatsData);
+        setCourseStats(courseStatsData);
+        setCategoryStats(categoryStatsData); // 상태 저장
+      } catch (error) {
+        console.error('대시보드 데이터 로딩 실패:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadDashboardData();
+  }, []); // 컴포넌트 마운트 시 1회 실행
+
+  // 로딩 중 표시
+  if (loading) {
+    return (
+      <S.PageWrapper>
+        <S.PageHeader>
+          <S.PageTitle>관리자 대시보드</S.PageTitle>
+        </S.PageHeader>
+        {/* 6. 실제 로딩 스피너 사용 */}
+        <S.LoadingContainer>
+          <LoadingSpinner />
+        </S.LoadingContainer>
+      </S.PageWrapper>
+    );
+  }
+
   return (
     <S.PageWrapper>
-      {/* 1. 페이지 헤더 */}
       <S.PageHeader>
         <S.PageTitle>관리자 대시보드</S.PageTitle>
         <S.DateDisplay>{todayDate}</S.DateDisplay>
       </S.PageHeader>
 
-      {/* 2. 대시보드 콘텐츠 영역 (프롬프트 순서대로 섹션 배치) */}
       <S.ContentLayout>
-        <StatsCardArea />
-        <ChartArea />
-        <ProgressArea />
-        <TableArea />
+        {/* ▼▼▼ 7. 자식 컴포넌트에 props로 데이터 전달 ▼▼▼ */}
+        <StatsCardArea stats={stats} dailyStats={dailyStats} />
+        <ChartArea dailyStats={dailyStats} />
+        <ProgressArea
+          courseStats={courseStats}
+          categoryStats={categoryStats}
+        />
+        <TableArea courseStats={courseStats} />
       </S.ContentLayout>
     </S.PageWrapper>
   );
 }
 
-// --- Styles (제공해주신 theme.ts 기반으로 적용) ---
-// (styled.d.ts 파일에 전역 테마 타입이 선언되었다고 가정합니다)
-
+// --- Styles ---
 const S = {
   PageWrapper: styled.div`
     display: flex;
     flex-direction: column;
     gap: 2.4rem;
     padding: 2.4rem;
-    background-color: ${({ theme }) => theme.colors.gray100}; // #F3F5FA
+    background-color: ${({ theme }) => theme.colors.gray100};
     min-height: 100vh;
   `,
-
   PageHeader: styled.header`
     display: flex;
     justify-content: space-between;
@@ -121,97 +124,25 @@ const S = {
     width: 100%;
   `,
   PageTitle: styled.h2`
-    font-size: ${({ theme }) => theme.fontSize.xl}; // 3.2rem
+    font-size: ${({ theme }) => theme.fontSize.xl};
     font-weight: 700;
-    color: ${({ theme }) => theme.colors.surface}; // #121314
+    color: ${({ theme }) => theme.colors.surface};
     margin: 0;
   `,
   DateDisplay: styled.span`
-    font-size: ${({ theme }) => theme.fontSize.md}; // 1.6rem
+    font-size: ${({ theme }) => theme.fontSize.md};
     font-weight: 500;
-    color: ${({ theme }) => theme.colors.gray300}; // #8D9299
+    color: ${({ theme }) => theme.colors.gray300};
   `,
-
   ContentLayout: styled.main`
     display: flex;
     flex-direction: column;
     gap: 2.4rem;
   `,
-
-  /** 1. 통계 카드 4개용 그리드 */
-  StatsGrid: styled.section`
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 2rem;
-
-    /* 992px 이하에서 2열 */
-    @media (${({ theme }) => theme.devices.laptop}) {
-      grid-template-columns: repeat(2, 1fr);
-    }
-    /* 478px 이하에서 1열 */
-    @media (${({ theme }) => theme.devices.mobile}) {
-      grid-template-columns: 1fr;
-    }
-  `,
-
-  /** 2. 차트 3개용 그리드 */
-  ChartGrid: styled.section`
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 2rem;
-
-    /* 992px 이하에서 1열 */
-    @media (${({ theme }) => theme.devices.laptop}) {
-      grid-template-columns: 1fr;
-    }
-  `,
-
-  /** 모든 섹션의 기본이 되는 카드 스타일 */
-  CardBox: styled.div`
-    background: ${({ theme }) => theme.colors.white}; // #FFFFFF
-    border-radius: ${({ theme }) => theme.radius.md}; // 1rem
-    padding: 2.4rem;
-    box-shadow: ${({ theme }) => theme.colors.shadow}; // 0 4px 20px 0 rgba(0, 0, 0, 0.04)
-  `,
-
-  /** (StatsCardArea) 통계 카드의 작은 제목 */
-  CardTitle: styled.h3`
-    font-size: ${({ theme }) => theme.fontSize.md}; // 1.6rem
-    font-weight: 600;
-    color: ${({ theme }) => theme.colors.gray400}; // #47494D
-    margin: 0 0 1.6rem 0;
-  `,
-
-  /** (Chart/Table) 섹션의 큰 제목 */
-  SectionTitle: styled.h3`
-    font-size: ${({ theme }) => theme.fontSize.lg}; // 2.4rem
-    font-weight: 600;
-    color: ${({ theme }) => theme.colors.surface}; // #121314
-    margin: 0 0 1.6rem 0;
-  `,
-
-  /** 통계 카드 내용 자리 표시자 */
-  CardContentPlaceholder: styled.div`
+  LoadingContainer: styled.div`
     display: flex;
-    align-items: center;
     justify-content: center;
-    min-height: 10rem;
-    font-size: 1.4rem;
-    color: ${({ theme }) => theme.colors.gray300};
-  `,
-  
-  /** 차트/테이블 영역 자리 표시자 */
-  ChartPlaceholder: styled.div`
-    display: flex;
     align-items: center;
-    justify-content: center;
-    min-height: 25rem;
-    background: ${({ theme }) => theme.colors.primary100}; // #DEE8FF
-    border-radius: ${({ theme }) => theme.radius.sm}; // 0.8rem
-    color: ${({ theme }) => theme.colors.primary300}; // #2E6FF2
-    font-size: ${({ theme }) => theme.fontSize.md};
-    font-weight: 500;
-    line-height: 1.6;
-    text-align: center;
+    height: 50vh;
   `,
 };

--- a/src/pages/Admin/ProgressArea.tsx
+++ b/src/pages/Admin/ProgressArea.tsx
@@ -1,0 +1,113 @@
+import React, { useMemo } from 'react';
+import styled from 'styled-components';
+import {
+  PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend,
+  RadialBarChart, RadialBar,
+  type PieLabelRenderProps // ◀◀◀ 1. PieLabelRenderProps 임포트
+} from 'recharts';
+import type { CategoryStat, CourseStat } from '../../types/AdminType';
+import { ErrorMessage, LoadingSpinner } from '../../components/HelperComponents';
+
+const COLORS = ['#0066FF', '#2E6FF2', '#B5CEFF', '#DEE8FF', '#8B38FF'];
+
+// Props 타입 정의
+interface ProgressAreaProps {
+  categoryStats: CategoryStat[] | null;
+  courseStats: CourseStat[] | null;
+}
+
+const ProgressArea: React.FC<ProgressAreaProps> = ({ categoryStats, courseStats }) => {
+  const loading = !categoryStats || !courseStats;
+
+  // 전체 강좌 평균 진도율 계산
+  const totalAvgProgress = useMemo(() => {
+    if (!courseStats || courseStats.length === 0) return 0;
+    const sum = courseStats.reduce((acc, course) => acc + course.avg_progress, 0);
+    return parseFloat((sum / courseStats.length).toFixed(1));
+  }, [courseStats]);
+
+  // 2. Pie Label 렌더 함수 (정확한 타입 사용)
+  const renderPieLabel = (props: PieLabelRenderProps) => {
+    if (typeof props.percent !== 'number') {
+      return '';
+    }
+    return `${props.name} (${(props.percent * 100).toFixed(0)}%)`;
+  };
+
+  return (
+    <S.ProgressGrid>
+      {/* 차트 1: 카테고리별 매출 비중 (PieChart) */}
+      <S.CardBox>
+        <S.SectionTitle>카테고리별 매출 비중</S.SectionTitle>
+        <S.ChartWrapper>
+          {loading && <LoadingSpinner />}
+          {!loading && !categoryStats && <ErrorMessage message="데이터 없음" />}
+          {categoryStats && (
+            <ResponsiveContainer width="100%" height={300}>
+              <PieChart>
+                <Pie
+                  // 3. recharts의 타입 정의가 엄격하지 않아 any[] 캐스팅이 필요할 수 있으나,
+                  //    우선 캐스팅 없이 시도합니다. 오류 시 'as any[]'가 필요합니다.
+                  data={categoryStats}
+                  cx="50%"
+                  cy="50%"
+                  dataKey="total_revenue"
+                  nameKey="category_name"
+                  outerRadius={100}
+                  fill="#8884d8"
+                  label={renderPieLabel} // 4. 수정된 렌더 함수 연결
+                >
+                  {categoryStats.map((_, index) => (
+                    <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                  ))}
+                </Pie>
+                <Tooltip formatter={(value: number) => `${value.toLocaleString()}원`} />
+                <Legend />
+              </PieChart>
+            </ResponsiveContainer>
+          )}
+        </S.ChartWrapper>
+      </S.CardBox>
+
+      {/* (차트 2: 전체 강좌 평균 진도율 - RadialBarChart) */}
+      <S.CardBox>
+        <S.SectionTitle>전체 강좌 평균 진도율</S.SectionTitle>
+        <S.ChartWrapper>
+          {loading && <LoadingSpinner />}
+          {courseStats && (
+            <ResponsiveContainer width="100%" height={300}>
+              <RadialBarChart
+                cx="50%" cy="50%"
+                innerRadius="60%" outerRadius="90%"
+                barSize={30}
+                data={[{ name: '평균', value: totalAvgProgress }]}
+                startAngle={90} endAngle={-270}
+              >
+                <RadialBar background dataKey="value" fill="#0066FF" />
+                <S.RadialLabel>
+                  <tspan x="50%" y="50%" dy="-0.5em" fontSize="2.4rem" fontWeight="700">
+                    {totalAvgProgress}%
+                  </tspan>
+                  <tspan x="50%" y="50%" dy="1.2em" fontSize="1.4rem" fill="#8D9299">
+                    평균 진도율
+                  </tspan>
+                </S.RadialLabel>
+              </RadialBarChart>
+            </ResponsiveContainer>
+          )}
+        </S.ChartWrapper>
+      </S.CardBox>
+    </S.ProgressGrid>
+  );
+};
+
+// --- Styles ---
+const S = {
+  ProgressGrid: styled.section`...`, // (스타일 동일)
+  CardBox: styled.div`...`,
+  SectionTitle: styled.h3`...`,
+  ChartWrapper: styled.div`...`,
+  RadialLabel: styled.text`...`,
+};
+
+export default ProgressArea;

--- a/src/pages/Admin/StatCard.tsx
+++ b/src/pages/Admin/StatCard.tsx
@@ -1,0 +1,115 @@
+import React, { type ReactNode } from 'react';
+import styled from 'styled-components';
+import { LoadingSpinner } from '../../components/HelperComponents'; // (공통 로딩 스피너 임포트)
+
+interface StatCardProps {
+  /** 카드 제목 (e.g., "오늘 접속자 수") */
+  title: string;
+  /** 카드에 표시될 아이콘 (ReactNode) */
+  icon: ReactNode;
+  /** 로딩 상태 */
+  loading: boolean;
+  /** 표시할 메인 값 (e.g., "120명") */
+  value: string | number;
+  /** 전일 대비 등락 (e.g., "+5.2%") */
+  change?: string;
+  /** 등락 값의 색상 (e.g., 'positive' | 'negative') */
+  changeType?: 'positive' | 'negative' | 'neutral';
+}
+
+/**
+ * 대시보드 상단의 개별 통계 카드를 표시하는 UI 컴포넌트
+ */
+export const StatCard: React.FC<StatCardProps> = ({
+  title,
+  icon,
+  loading,
+  value,
+  change,
+  changeType = 'neutral',
+}) => {
+  return (
+    <S.CardBox>
+      <S.CardHeader>
+        <S.CardTitle>{title}</S.CardTitle>
+        <S.IconWrapper>{icon}</S.IconWrapper>
+      </S.CardHeader>
+      <S.CardBody>
+        {loading ? (
+          <LoadingSpinner />
+        ) : (
+          <>
+            <S.ValueText>{value}</S.ValueText>
+            {change && (
+              <S.ChangeText $type={changeType}>{change}</S.ChangeText>
+            )}
+          </>
+        )}
+      </S.CardBody>
+    </S.CardBox>
+  );
+};
+
+// --- Styles ---
+
+const S = {
+  CardBox: styled.div`
+    background: ${({ theme }) => theme.colors.white};
+    border-radius: ${({ theme }) => theme.radius.md};
+    padding: 2.4rem;
+    box-shadow: ${({ theme }) => theme.colors.shadow};
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    min-height: 16rem; // 카드 최소 높이
+  `,
+  CardHeader: styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 1.6rem;
+  `,
+  CardTitle: styled.h3`
+    font-size: ${({ theme }) => theme.fontSize.md}; // 1.6rem
+    font-weight: 600;
+    color: ${({ theme }) => theme.colors.gray400};
+    margin: 0;
+  `,
+  IconWrapper: styled.div`
+    width: 3.2rem;
+    height: 3.2rem;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: ${({ theme }) => theme.colors.primary100}; // #DEE8FF
+    color: ${({ theme }) => theme.colors.primary300}; // #2E6FF2
+
+    // 아이콘 SVG 크기 조절 (임시)
+    svg,
+    span {
+      font-size: 1.8rem;
+    }
+  `,
+  CardBody: styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    min-height: 4.8rem; // 로딩 스피너 공간 확보
+  `,
+  ValueText: styled.span`
+    font-size: ${({ theme }) => theme.fontSize.xl}; // 3.2rem
+    font-weight: 700;
+    color: ${({ theme }) => theme.colors.surface};
+  `,
+  ChangeText: styled.span<{ $type: string }>`
+    font-size: ${({ theme }) => theme.fontSize.sm};
+    font-weight: 600;
+    color: ${({ theme, $type }) =>
+      $type === 'positive'
+        ? theme.colors.primary300 // (임시) 상승색
+        : $type === 'negative'
+        ? theme.colors.alert // 하락색
+        : theme.colors.gray300}; // 중립색
+  `,
+};

--- a/src/pages/Admin/StatsCardArea.tsx
+++ b/src/pages/Admin/StatsCardArea.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import styled from 'styled-components';
+import { StatCard } from './StatCard'; // (이전과 동일한 StatCard UI 컴포넌트)
+import type { AdminStats, DailyStat } from '../../types/AdminType';
+
+// (임시) 아이콘
+const VisitIcon = () => <span>👥</span>;
+const ViewIcon = () => <span>👁️</span>;
+const RevenueIcon = () => <span>💳</span>;
+const NewUserIcon = () => <span>🧾</span>;
+
+// (헬퍼 함수)
+const formatCurrency = (amount: number) => `${amount.toLocaleString()}원`;
+const formatNumber = (amount: number) => `${amount.toLocaleString()}명`;
+const formatView = (amount: number) => `${amount.toLocaleString()}회`;
+
+// Props 타입 정의
+interface StatsCardAreaProps {
+  stats: AdminStats | null;
+  dailyStats: DailyStat[] | null;
+}
+
+const StatsCardArea: React.FC<StatsCardAreaProps> = ({ stats, dailyStats }) => {
+  // 데이터가 로드되기 전(null)이거나, 로딩 중(부모에서)일 때를 대비
+  const loading = !stats || !dailyStats;
+
+  // Swagger 기준, '신규 회원 수'는 dailyStats의 마지막 항목(오늘)에서 가져옵니다.
+  const todayNewUsers =
+    dailyStats && dailyStats.length > 0
+      ? dailyStats[dailyStats.length - 1].new_users
+      : 0;
+
+  return (
+    <S.StatsGrid>
+      <StatCard
+        title="오늘 접속자 수"
+        icon={<VisitIcon />}
+        loading={loading}
+        value={loading ? '...' : formatNumber(stats?.today_visitors ?? 0)}
+      />
+      <StatCard
+        title="오늘 조회수"
+        icon={<ViewIcon />}
+        loading={loading}
+        value={loading ? '...' : formatView(stats?.today_views ?? 0)}
+      />
+      <StatCard
+        title="오늘 결제액"
+        icon={<RevenueIcon />}
+        loading={loading}
+        value={loading ? '...' : formatCurrency(stats?.today_revenue ?? 0)}
+      />
+      <StatCard
+        title="신규 회원 수"
+        icon={<NewUserIcon />}
+        loading={loading}
+        value={loading ? '...' : formatNumber(todayNewUsers)}
+      />
+    </S.StatsGrid>
+  );
+};
+
+const S = {
+  StatsGrid: styled.section`
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 2rem;
+    @media (${({ theme }) => theme.devices.laptop}) {
+      grid-template-columns: repeat(2, 1fr);
+    }
+    @media (${({ theme }) => theme.devices.mobile}) {
+      grid-template-columns: 1fr;
+    }
+  `,
+};
+
+export default StatsCardArea;

--- a/src/pages/Admin/TableArea.tsx
+++ b/src/pages/Admin/TableArea.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import styled from 'styled-components';
+import type { CourseStat } from '../../types/AdminType';
+import { ErrorMessage, LoadingSpinner } from '../../components/HelperComponents';
+
+// Props 타입 정의
+interface TableAreaProps {
+  courseStats: CourseStat[] | null;
+}
+
+const TableArea: React.FC<TableAreaProps> = ({ courseStats }) => {
+  const loading = !courseStats;
+
+  return (
+    <S.CardBox>
+      <S.SectionHeader>
+        <S.SectionTitle>강의별 통계</S.SectionTitle>
+        {/* ( ... TableActions ... ) */}
+      </S.SectionHeader>
+
+      {loading && <LoadingSpinner />}
+      {!loading && !courseStats && <ErrorMessage message="데이터 없음" />}
+      
+      <S.TableWrapper>
+        <S.StyledTable>
+          <thead>
+            <tr>
+              <th>카테고리</th>
+              <th>강의명</th>
+              <th>매출</th>
+              <th>수강생(활성)</th>
+              <th>평균 진도율</th>
+              <th>완료율</th>
+            </tr>
+          </thead>
+          <tbody>
+            {!loading && courseStats?.length === 0 && (
+              <tr><td colSpan={6}>데이터가 없습니다.</td></tr>
+            )}
+            {courseStats?.map((course) => (
+              <tr key={course.course_id}>
+                <td>{course.category_name}</td>
+                <td>{course.course_title}</td>
+                <td>{course.total_revenue.toLocaleString()}원</td>
+                <td>
+                  {course.total_enrollments.toLocaleString()}
+                  <span className="active">
+                    ({course.active_enrollments.toLocaleString()})
+                  </span>
+                </td>
+                <td>{course.avg_progress.toFixed(1)}%</td>
+                <td>{course.completion_rate.toFixed(1)}%</td>
+              </tr>
+            ))}
+          </tbody>
+        </S.StyledTable>
+      </S.TableWrapper>
+    </S.CardBox>
+  );
+};
+
+// --- Styles ---
+const S = {
+  CardBox: styled.div`
+    background: ${({ theme }) => theme.colors.white};
+    border-radius: ${({ theme }) => theme.radius.md};
+    padding: 2.4rem;
+    box-shadow: ${({ theme }) => theme.colors.shadow};
+  `,
+  SectionHeader: styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 2.4rem;
+    @media (${({ theme }) => theme.devices.tablet}) {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 1.6rem;
+    }
+  `,
+  SectionTitle: styled.h3`
+    font-size: ${({ theme }) => theme.fontSize.lg}; // 2.4rem
+    font-weight: 600;
+    color: ${({ theme }) => theme.colors.surface};
+    margin: 0;
+  `,
+  ActionWrapper: styled.div`
+    display: flex;
+    gap: 1.2rem;
+  `,
+  SearchInput: styled.input`
+    height: 4rem;
+    padding: 0 1.6rem;
+    border: 1px solid ${({ theme }) => theme.colors.gray200};
+    border-radius: ${({ theme }) => theme.radius.sm};
+    font-size: 1.4rem;
+    &:focus {
+      border-color: ${({ theme }) => theme.colors.primary300};
+      outline: none;
+    }
+  `,
+  ActionButton: styled.button`
+    height: 4rem;
+    padding: 0 1.6rem;
+    background: ${({ theme }) => theme.colors.gray100};
+    color: ${({ theme }) => theme.colors.gray400};
+    border: 1px solid ${({ theme }) => theme.colors.gray200};
+    border-radius: ${({ theme }) => theme.radius.sm};
+    font-size: 1.4rem;
+    font-weight: 500;
+    cursor: pointer;
+    &:hover {
+      background: ${({ theme }) => theme.colors.gray200};
+    }
+  `,
+  TableWrapper: styled.div`
+    width: 100%;
+    overflow-x: auto; // 모바일/태블릿에서 가로 스크롤
+  `,
+  StyledTable: styled.table`
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 1.4rem;
+    th,
+    td {
+      padding: 1.6rem 1.2rem;
+      text-align: left;
+      border-bottom: 1px solid ${({ theme }) => theme.colors.gray100};
+      white-space: nowrap;
+    }
+    th {
+      font-weight: 600;
+      color: ${({ theme }) => theme.colors.gray300};
+      background: ${({ theme }) => theme.colors.white}; // (thead 고정 시 필요)
+    }
+    td {
+      color: ${({ theme }) => theme.colors.surface};
+      .active {
+        color: ${({ theme }) => theme.colors.primary300};
+        font-size: 1.3rem;
+        margin-left: 0.4rem;
+      }
+    }
+    tbody tr:hover {
+      background: ${({ theme }) => theme.colors.gray100};
+    }
+    tbody td[colSpan] {
+      text-align: center;
+      padding: 4rem;
+      color: ${({ theme }) => theme.colors.gray300};
+    }
+  `,
+};
+export default TableArea;

--- a/src/pages/Lecture/components/CurriculumSection.tsx
+++ b/src/pages/Lecture/components/CurriculumSection.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { useApiData } from '../../../hooks/useApiData';
-import { mockCurriculumData } from '../../../data/mockData';
+import { mockCurriculumData } from '../../../data/mockLectureData';
 import type { CurriculumData } from '../../../types/LectureType';
 import { ErrorMessage, LoadingSpinner } from '../../../components/HelperComponents';
 import ArrowDownIcon from '../../../assets/icons/icon-arrow-down.svg?react';

--- a/src/pages/Lecture/components/FAQSection.tsx
+++ b/src/pages/Lecture/components/FAQSection.tsx
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { useApiData } from '../../../hooks/useApiData';
-import { mockFaqData } from '../../../data/mockData';
+import { mockFaqData } from '../../../data/mockLectureData';
 import type { FaqData } from '../../../types/LectureType';
 import { LoadingSpinner, ErrorMessage } from '../../../components/HelperComponents';
 import ArrowDownIcon from '../../../assets/icons/icon-arrow-down.svg?react';

--- a/src/pages/Lecture/components/InstructorSection.tsx
+++ b/src/pages/Lecture/components/InstructorSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useApiData } from '../../../hooks/useApiData';
-import { mockInstructorData } from '../../../data/mockData';
+import { mockInstructorData } from '../../../data/mockLectureData';
 import type { Instructor } from '../../../types/LectureType';
 import { LoadingSpinner, ErrorMessage } from '../../../components/HelperComponents';
 

--- a/src/pages/Lecture/components/LectureBannerSection.tsx
+++ b/src/pages/Lecture/components/LectureBannerSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useApiData } from '../../../hooks/useApiData';
-import { mockBannerData } from '../../../data/mockData';
+import { mockBannerData } from '../../../data/mockLectureData';
 import type { BannerData } from '../../../types/LectureType';
 import { LoadingSpinner, ErrorMessage } from '../../../components/HelperComponents';
 

--- a/src/pages/Lecture/components/LectureHeaderSection.tsx
+++ b/src/pages/Lecture/components/LectureHeaderSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useApiData } from '../../../hooks/useApiData';
-import { mockHeaderData } from '../../../data/mockData';
+import { mockHeaderData } from '../../../data/mockLectureData';
 import type { LectureHeaderData } from '../../../types/LectureType';
 import { LoadingSpinner, ErrorMessage } from '../../../components/HelperComponents';
 

--- a/src/pages/Lecture/components/LectureInfoBox.tsx
+++ b/src/pages/Lecture/components/LectureInfoBox.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useApiData } from '../../../hooks/useApiData';
-import { mockCardData } from '../../../data/mockData';
+import { mockCardData } from '../../../data/mockLectureData';
 import type { CardData } from '../../../types/LectureType';
 import { LoadingSpinner, ErrorMessage } from '../../../components/HelperComponents';
 import Button from '../../../components/Button';

--- a/src/pages/Lecture/components/NoticeSection.tsx
+++ b/src/pages/Lecture/components/NoticeSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useApiData } from '../../../hooks/useApiData';
-import { mockNoticeData } from '../../../data/mockData';
+import { mockNoticeData } from '../../../data/mockLectureData';
 import type { NoticeData } from '../../../types/LectureType';
 
 const NoticeSection: React.FC = () => {

--- a/src/pages/Lecture/components/ReviewSection.tsx
+++ b/src/pages/Lecture/components/ReviewSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useApiData } from '../../../hooks/useApiData';
-import { mockReviewData } from '../../../data/mockData';
+import { mockReviewData } from '../../../data/mockLectureData';
 import type { ReviewData } from '../../../types/LectureType';
 import { LoadingSpinner, ErrorMessage } from '../../../components/HelperComponents'; // 로딩/에러 컴포넌트 (별도 파일 추천)
 

--- a/src/pages/MyPage/AccountSection.tsx
+++ b/src/pages/MyPage/AccountSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useApiData } from '../../hooks/useApiData';
-import { mockAccountData } from '../../data/mockData';
+import { mockAccountData } from '../../data/mockMyPageData';
 import { LoadingSpinner, ErrorMessage } from '../../components/HelperComponents';
 
 const AccountSection: React.FC = () => {

--- a/src/pages/MyPage/OrderHistorySection.tsx
+++ b/src/pages/MyPage/OrderHistorySection.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import styled from 'styled-components';
 import { useApiData } from '../../hooks/useApiData';
-import { mockOrderData } from '../../data/mockData';
+import { mockOrderData } from '../../data/mockMyPageData';
 import type { OrderData, OrderItem } from '../../types/ProfileType';
 import { LoadingSpinner, ErrorMessage } from '../../components/HelperComponents';
 

--- a/src/pages/MyPage/ProfilePage.tsx
+++ b/src/pages/MyPage/ProfilePage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { useApiData } from '../../hooks/useApiData';
-import { mockProfileData } from '../../data/mockData';
+import { mockProfileData } from '../../data/mockMyPageData';
 import { LoadingSpinner, ErrorMessage } from '../../components/HelperComponents';
 import CalendarIconSvg from '../../assets/icons/icon-calendar.svg';
 

--- a/src/types/AdminType.ts
+++ b/src/types/AdminType.ts
@@ -1,0 +1,97 @@
+/**
+ * /admin/dashboard/stats
+ * (통계 카드용)
+ */
+export interface AdminStats {
+  total_users: number;
+  total_courses: number;
+  total_enrollments: number;
+  active_enrollments: number;
+  total_revenue: number;
+  pending_refunds: number;
+  today_visitors: number;
+  today_views: number;
+  today_revenue: number;
+}
+
+/**
+ * /admin/dashboard/daily-stats
+ * (일별 접속/매출 차트용)
+ */
+export interface DailyStat {
+  date: string; // "YYYY-MM-DD"
+  visitors: number;
+  views: number;
+  revenue: number;
+  enrollments: number;
+  new_users: number;
+}
+
+/**
+ * /admin/dashboard/revenue-stats
+ * (일별 상세 매출 차트용)
+ */
+export interface RevenueStat {
+  date: string; // "YYYY-MM-DD"
+  revenue: number;
+  payment_count: number;
+  refund_amount: number;
+  refund_count: number;
+  net_revenue: number;
+}
+
+/**
+ * /admin/dashboard/course-stats
+ * (강의별 통계 테이블/차트용)
+ */
+export interface CourseStat {
+  course_id: number;
+  course_title: string;
+  category_name: string;
+  total_enrollments: number;
+  active_enrollments: number;
+  avg_progress: number;
+  completion_count: number;
+  completion_rate: number;
+  total_revenue: number;
+}
+
+/**
+ * /admin/dashboard/category-stats
+ * (카테고리별 통계 차트용)
+ */
+export interface CategoryStat {
+  category_id: number;
+  category_name: string;
+  course_count: number;
+  total_enrollments: number;
+  total_revenue: number;
+  avg_completion_rate: number;
+  [key: string]: unknown;
+}
+
+/**
+ * /admin/dashboard/settings
+ * (시스템 설정용)
+ */
+export interface AdminSettings {
+  site_name: string;
+  course_price: number;
+  enrollment_period_years: number;
+  refund_period_days: number;
+  refund_progress_limit: number;
+  passing_score_rate: number;
+}
+
+/**
+ * API 함수에 전달할 파라미터 타입 (예시)
+ */
+export interface DateRangeParams {
+  period?: 'day' | 'week' | 'month' | 'year';
+  start_date?: string;
+  end_date?: string;
+}
+
+export interface CourseStatParams extends DateRangeParams {
+  category_id?: number;
+}


### PR DESCRIPTION
Closes: #45

 - 요약
: 관리자 대시보드 페이지(DashboardPage)의 기본 UI를 구현합니다. 페이지 레벨에서 필요한 모든 API 데이터를 Promise.all로 일괄 호출하고, 하위 컴포넌트에는 props로 데이터를 전달하여 UI를 렌더링하는 컨테이너/프레젠테이션 패턴을 적용했습니다.

 - 핵심 변경 사항
A. 데이터 관리 (부모)
: DashboardPage.tsx: 페이지 진입 시 4개의 API(stats, dailyStats, courseStats, categoryStats)를 한 번에 호출하고, 전체 로딩 상태를 관리합니다.
B. UI 컴포넌트 (자식)
: StatsCardArea.tsx: 4개의 핵심 요약 카드(접속자, 조회수, 결제액, 신규 회원)를 표시합니다.
: ChartArea.tsx: recharts (Line, Bar)를 사용해 일별 통계 차트 3종을 렌더링합니다.
: ProgressArea.tsx: recharts (Pie, RadialBar)를 사용해 카테고리별 매출 비중과 평균 진도율을 시각화합니다.
: TableArea.tsx: 강의별 통계 데이터를 테이블 형태로 렌더링합니다.

- 타입 및 오류 수정
: AdminType.ts: recharts의 data prop과 타입 호환을 위해 CategoryStat 타입에 [key: string]: unknown; 인덱스 시그니처를 추가했습니다.
: any 타입 제거: eslint-disable이나 as any[] 대신 unknown 타입과 recharts의 공식 타입(TooltipProps, PieLabelRenderProps)을 사용하여 TypeScript 오류를 근본적으로 해결했습니다.
: no-unused-vars: .map()의 미사용 파라미터를 _로 대체하여 린트 오류를 수정했습니다.

- 참고 사항
: recharts 라이브러리 설치가 필요합니다.
  --> npm install recharts 
: StatCard.tsx (요약 카드 UI), mockAdminData.ts (목업 데이터), adminApi.ts (API 함수) 등이 함께 추가되었습니다.