### PR TITLE
[FIX] 강의실 Header Style 수정 #85

### DIFF
--- a/src/components/ButtonIcon.tsx
+++ b/src/components/ButtonIcon.tsx
@@ -74,6 +74,7 @@ const StyledButtonIcon = styled.button<{
         p.$variant === "discord" &&
         css`
             background-color: ${({ theme }) => theme.colors.gray400};
+            color: ${({ theme }) => theme.colors.white};
             svg path {
                 fill: ${({ theme }) => theme.colors.white};
             }
@@ -84,7 +85,6 @@ const StyledButtonIcon = styled.button<{
         (p.$tooltip || p.$variant === "discord") &&
         css`
             position: relative;
-            color: ${({ theme }) => theme.colors.white}; 
 
             &::before,
             &::after {


### PR DESCRIPTION
## 개요
- 강의실 Header Style 수정

## 변경사항
- 강의실 오른쪽 상단 Header 아이콘이 안 보여서(color: white) CSS 코드 수정

**Closes #85 