### PR TITLE
 [FIX] 회원가입 인증 코드 보안 강화 #188

### DIFF
--- a/src/api/authApi.ts
+++ b/src/api/authApi.ts
@@ -193,7 +193,6 @@ export const requestEmailVerification = async (
   if (!useMock) {
     console.log('Requesting email verification for:', payload);
     const response = await apiClient.post(API_URL.AUTH.EMAIL_VERIFICATION_REQUEST, payload);
-    console.log('Email verification request response:', response);
     return response.data; // (data.data가 아닌 data로 추정)
   } else {
     return new Promise((resolve) => setTimeout(() => resolve(mockResponse), 500));

--- a/src/pages/Auth/hooks/useSignUpForm.ts
+++ b/src/pages/Auth/hooks/useSignUpForm.ts
@@ -55,6 +55,7 @@ interface UseSignUpFormReturn {
   formState: FormState;
   errorState: ErrorState;
   emailVerification: EmailVerificationState;
+  isSendingCode: boolean;
 
   // 핸들러 함수들
   handleEmailChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -100,9 +101,9 @@ export const useSignUpForm = (): UseSignUpFormReturn => {
   const [nickNameError, setNickNameError] = useState<string | boolean>(false);
 
   // 인증 상태
-  const [isEmailSent, setIsEmailSent] = useState(false);
-  const [isEmailVerified, setIsEmailVerified] = useState(false);
-  const [showEmailHelp, setShowEmailHelp] = useState(false);
+  const [isEmailSent, setIsEmailSent] = useState(false);    // 이메일 인증 요청 상태
+  const [isEmailVerified, setIsEmailVerified] = useState(false); // 이메일 인증 완료 상태
+  const [showEmailHelp, setShowEmailHelp] = useState(false);  // 이메일 도움말 상태
 
   // API 메시지 상태
   const [apiMessage, setApiMessage] = useState<ApiMessageState>({
@@ -225,12 +226,13 @@ export const useSignUpForm = (): UseSignUpFormReturn => {
     requestVerifyMutate(
       { email },
       {
-        onSuccess: (data) => {
+        onSuccess: () => {
+          // 이제는 code를 리턴하지 않음, 이메일에서 확이하여 직접 입력해야함.
+          // 인증 요청후 응답이 올때까지 인증버튼이 활성화 되어있어서 여러번 누를 수 있는 문제 상태가 있음
           setIsEmailSent(true);
-          const code = data.detail.split(': ')[1] || '???';
           setApiMessage({
             type: 'success',
-            message: `인증 코드가 발송되었습니다. (코드: ${code})`,
+            message: '인증 코드가 발송되었습니다.',
           });
         },
         onError: (error) => {
@@ -274,12 +276,11 @@ export const useSignUpForm = (): UseSignUpFormReturn => {
     requestVerifyMutate(
       { email },
       {
-        onSuccess: (data) => {
+        onSuccess: () => {
           setIsEmailSent(true);
-          const code = data.detail.split(': ')[1] || '???';
           setApiMessage({
             type: 'success',
-            message: `인증 코드가 재전송되었습니다. (코드: ${code})`,
+            message: '인증 코드가 재전송되었습니다.',
           });
         },
         onError: (error) => {
@@ -340,6 +341,7 @@ export const useSignUpForm = (): UseSignUpFormReturn => {
       isEmailVerified,
       showEmailHelp,
     },
+    isSendingCode,
     handleEmailChange,
     handlePasswordChange,
     handlePasswordConfirmChange,

--- a/src/pages/Auth/pages/SignUpPage.tsx
+++ b/src/pages/Auth/pages/SignUpPage.tsx
@@ -61,6 +61,7 @@ const SignUpPage = () => {
     isSignUpEnabled: isFormValid,
     handleSignUp,
     apiMessage,
+    isSendingCode,
   } = useSignUpForm();
 
   // 약관 동의 로직
@@ -133,11 +134,16 @@ const SignUpPage = () => {
                   disabled={
                     !validateEmail(formState.email) ||
                     emailVerification.isEmailSent ||
-                    emailVerification.isEmailVerified
+                    emailVerification.isEmailVerified ||
+                    isSendingCode
                   }
                   onClick={handleEmailVerification}
                 >
-                  {emailVerification.isEmailVerified ? '인증 완료' : '인증'}
+                  {emailVerification.isEmailVerified
+                    ? '인증 완료'
+                    : isSendingCode
+                      ? '전송 중...'
+                      : '인증'}
                 </VerifyButton>
               </EmailInputWrapper>
               {errorState.email && <HelperMessage $type="error">{errorState.email}</HelperMessage>}

--- a/src/queries/useAuthQueries.ts
+++ b/src/queries/useAuthQueries.ts
@@ -26,6 +26,7 @@ export const useVerifyAuth = () => {
     queryKey: authKeys.verify, // 고정된 쿼리 키
     queryFn: verifyToken, // API 함수
     retry: false, // 토큰 검증 실패 시 재시도하지 않음
+    enabled: !!localStorage.getItem('accessToken'), // 토큰이 있을 때만 검증 실행
   });
 
   React.useEffect(() => {


### PR DESCRIPTION
## 개요

- 이메일 인증 요청 시 중복 클릭을 방지하여 UX를 개선했습니다.
- 불필요한 토큰 검증 API 호출을 방지하여 성능을 최적화했습니다.

## 변경사항

### 이메일 인증 (SignUp)
- **중복 요청 방지**: 인증 코드 전송 중일 때 버튼을 비활성화하고 '전송 중...' 상태를 표시하도록 수정했습니다.
- **코드 정리**: `onSuccess` 콜백에서 사용하지 않는 `data` 파라미터 처리 로직을 제거했습니다.

### 인증 로직 (Auth)
- **토큰 검증 최적화**: `useVerifyAuth` 훅에서 `localStorage`에 `accessToken`이 존재할 때만 API를 호출하도록 변경했습니다.
    - 로그인/회원가입 페이지 등 토큰이 없는 환경에서 불필요한 401 에러 및 API 호출을 방지합니다.

Closes #188 
