### PR TITLE
[FEAT] 인트로 페이지 구현 및 라우트 변경 (#202)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,18 @@
 <!doctype html>
 <html lang="ko-KR">
-  <head>
-    <meta charset="UTF-8" />   
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>부트런 - ICT 교육 플랫폼</title>
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>부트런 - ICT 교육 플랫폼</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;700&display=swap" rel="stylesheet">
+
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+
 </html>

--- a/src/hooks/useDeleteAccountHandler.ts
+++ b/src/hooks/useDeleteAccountHandler.ts
@@ -3,6 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { useDeleteAccount } from '../queries/useUserQueries';
 import type { ResponseErrorDeleteAccount } from '../types/api';
+import { ROUTES } from '../router/RouteConfig';
 
 interface UseDeleteAccountHandlerProps {
   onClose: () => void; // 모달 닫기 콜백
@@ -37,7 +38,7 @@ export const useDeleteAccountHandler = ({ onClose }: UseDeleteAccountHandlerProp
           queryClient.clear(); // 모든 캐시 삭제
           localStorage.clear(); // (권장) 스토리지 클리어
           onClose();
-          navigate('/'); // 홈으로 이동
+          navigate(ROUTES.HOME); // 홈으로 이동
         },
         onError: (error) => {
           const errorResponse = error as ResponseErrorDeleteAccount;

--- a/src/pages/Intro/IntroPage.tsx
+++ b/src/pages/Intro/IntroPage.tsx
@@ -1,0 +1,198 @@
+import React, { useEffect } from 'react';
+import styled, { keyframes, type DefaultTheme } from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+import { ROUTES } from '../../router/RouteConfig';
+
+
+const Container = styled.div`
+  background-color: ${({ theme }) => theme.colors.white}; 
+  color: ${({ theme }) => theme.colors.primary300}; 
+  font-family: 'Fira Code', monospace; 
+  overflow: hidden;
+  font-weight: 700;
+  height: 100vh;
+  width: 100vw;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 9999;
+`;
+
+const TerminalPrompt = styled.span`
+  color: ${({ theme }) => theme.colors.surface}; 
+  margin-right: 0.5rem;
+  font-size: 4rem;
+
+  @media (max-width: 768px) {
+    font-size: 2rem;
+  }
+`;
+
+const typing = keyframes`
+  from { width: 0 }
+  to { width: 100% }
+`;
+
+const blinkCaret = (theme: DefaultTheme) => keyframes`
+  from, to { border-color: transparent }    
+  50% { border-color: ${theme.colors.primary300}; }
+`;
+
+const TypewriterText = styled.div`
+  overflow: hidden;
+  border-right: .15em solid ${({ theme }) => theme.colors.primary300}; 
+  white-space: nowrap; 
+  margin: 0 auto;
+  letter-spacing: .15em;
+  font-size: 4rem;
+  width: 0;
+  display: inline-block; 
+  
+  /* 애니메이션 적용: 타이핑(1s) + 커서 깜빡임(무한) */
+  animation: 
+    ${typing} 1s steps(8, end) forwards,
+    ${({ theme }) => blinkCaret(theme)} .75s step-end infinite;
+    
+  @media (max-width: 768px) {
+    font-size: 2rem;
+  }
+`;
+
+const RunHighlight = styled.span`
+  color: ${({ theme }) => theme.colors.surface}; 
+  font-weight: bold;
+`;
+
+const TerminalScene = styled.div`
+  display: flex;
+  align-items: center;
+  
+`;
+
+const TerminalWindow = styled.div`
+  background-color: ${({ theme }) => theme.colors.white};
+  border: 2px solid ${({ theme }) => theme.colors.gray200};
+  border-radius: ${({ theme }) => theme.radius.lg};
+  box-shadow: ${({ theme }) => theme.shadows.xl};
+  padding: 6rem 8rem;
+  position: relative;
+  
+  @media (max-width: 768px) {
+    min-width: 100%;
+    width: 100%;
+    height: 100%;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+`;
+
+const MacWindowHeader = styled.div`
+  position: absolute;
+  top: 1rem;
+  left: 1.5rem;
+  display: flex;
+  gap: 0.6rem;
+
+  @media (max-width: 768px) {
+    display: none;
+  }
+`;
+
+const MacWindowDot = styled.div<{ color: string }>`
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background-color: ${({ color }) => color};
+`;
+
+const WindowsWindowHeader = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: flex;
+
+  @media (max-width: 768px) {
+    display: none;
+  }
+`;
+
+const WindowsBtn = styled.div<{ isClose?: boolean }>`
+  width: 46px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  color: ${({ theme }) => theme.colors.surface};
+  cursor: default;
+  transition: background-color 0.2s;
+  border-top-right-radius: ${({ isClose, theme }) => (isClose ? theme.radius.lg : '0')};
+
+  &:hover {
+    background-color: ${({ isClose }) => (isClose ? '#E81123' : '#E5E5E5')};
+    color: ${({ isClose }) => (isClose ? 'white' : 'inherit')};
+  }
+`;
+
+// OS 감지 유틸리티
+const getOS = () => {
+  const userAgent = window.navigator.userAgent.toLowerCase();
+  if (userAgent.includes('win')) return 'windows';
+  if (userAgent.includes('mac')) return 'mac';
+  return 'mac'; // 기본값
+};
+
+const IntroPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [os, setOs] = React.useState<'mac' | 'windows'>('mac');
+
+  useEffect(() => {
+    setOs(getOS());
+
+    // 2.5초 후 메인 페이지로 이동 (애니메이션 1s + 대기 1.5s)
+    const timer = setTimeout(() => {
+      navigate(ROUTES.HOME);
+    }, 2500);
+
+    return () => clearTimeout(timer);
+  }, [navigate]);
+
+  return (
+    <>
+      <Container>
+        <TerminalWindow>
+          {os === 'mac' ? (
+            <MacWindowHeader>
+              <MacWindowDot color="#FF5F56" /> {/* Red */}
+              <MacWindowDot color="#FFBD2E" /> {/* Yellow */}
+              <MacWindowDot color="#27C93F" /> {/* Green */}
+            </MacWindowHeader>
+          ) : (
+            <WindowsWindowHeader>
+              <WindowsBtn>&#9472;</WindowsBtn> {/* Minimize */}
+              <WindowsBtn>&#9633;</WindowsBtn> {/* Maximize */}
+              <WindowsBtn isClose>&#10005;</WindowsBtn> {/* Close */}
+            </WindowsWindowHeader>
+          )}
+          <TerminalScene>
+            <TerminalPrompt>&gt;_</TerminalPrompt>
+            <TypewriterText>
+              boot<RunHighlight>:run</RunHighlight>
+            </TypewriterText>
+          </TerminalScene>
+        </TerminalWindow>
+      </Container>
+    </>
+  );
+};
+
+export default IntroPage;

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -12,6 +12,7 @@ import {
 } from './NotFoundPage.styled';
 import Button from '../components/Button';
 import errorImage from '../assets/images/bg-404.png';
+import { ROUTES } from '../router/RouteConfig';
 
 export default function NotFoundPage() {
   const navigate = useNavigate();
@@ -27,7 +28,7 @@ export default function NotFoundPage() {
 
   //메인으로 이동
   const handleGoHome = () => {
-    navigate('/');
+    navigate(ROUTES.HOME);
   };
 
   //이전 페이지 이동
@@ -36,28 +37,28 @@ export default function NotFoundPage() {
   };
 
   return (
-      <ContentWrapper role="main" id="main-content" tabIndex={-1} aria-labelledby="not-found-title">
-        <ImageWrapper>
-          <ErrorImage src={errorImage} alt="" role="presentation" aria-hidden="true" />
-        </ImageWrapper>
+    <ContentWrapper role="main" id="main-content" tabIndex={-1} aria-labelledby="not-found-title">
+      <ImageWrapper>
+        <ErrorImage src={errorImage} alt="" role="presentation" aria-hidden="true" />
+      </ImageWrapper>
 
-        <TextAndButtonWrapper>
-          <TextWrapper>
-            <Title id="not-found-title">페이지를 찾을 수 없습니다.</Title>
-            <Description>
-              앗, 이 페이지는 없는 것 같아요. 주소를 다시 확인하거나 메인 페이지로 돌아가주세요.
-            </Description>
-          </TextWrapper>
+      <TextAndButtonWrapper>
+        <TextWrapper>
+          <Title id="not-found-title">페이지를 찾을 수 없습니다.</Title>
+          <Description>
+            앗, 이 페이지는 없는 것 같아요. 주소를 다시 확인하거나 메인 페이지로 돌아가주세요.
+          </Description>
+        </TextWrapper>
 
-          <ButtonWrapper>
-            <Button variant="primary" size="md" onClick={handleGoHome}>
-              메인으로
-            </Button>
-            <Button variant="outline" size="md" onClick={handleGoBack}>
-              이전 페이지
-            </Button>
-          </ButtonWrapper>
-        </TextAndButtonWrapper>
-      </ContentWrapper>
+        <ButtonWrapper>
+          <Button variant="primary" size="md" onClick={handleGoHome}>
+            메인으로
+          </Button>
+          <Button variant="outline" size="md" onClick={handleGoBack}>
+            이전 페이지
+          </Button>
+        </ButtonWrapper>
+      </TextAndButtonWrapper>
+    </ContentWrapper>
   );
 }

--- a/src/queries/useAuthQueries.ts
+++ b/src/queries/useAuthQueries.ts
@@ -17,6 +17,7 @@ import type {
 import type { ResponseError } from '../types/api';
 import { useNavigate } from 'react-router-dom';
 import { authKeys, userKeys } from './queryKeys';
+import { ROUTES } from '../router/RouteConfig';
 
 export const useVerifyAuth = () => {
   const queryClient = useQueryClient();
@@ -62,7 +63,7 @@ export const useLogin = () => {
     onSuccess: (data) => {
       console.log('로그인 성공:', data);
       queryClient.setQueryData(userKeys.me, data.user); // 사용자 데이터 캐시에 저장
-      navigate('/'); // 로그인 성공 시 메인 페이지로 이동
+      navigate(ROUTES.HOME); // 로그인 성공 시 메인 페이지로 이동
     },
     onError: (error: ResponseError) => {
       console.error('로그인 실패:', error.response?.data?.detail?.detail);

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -31,6 +31,7 @@ const MyLecturePage = lazy(() => import('../pages/Lecture/pages/MyLecturePage'))
 const LectureRoomPage = lazy(() => import('../pages/Lecture/pages/LectureRoomPage'));
 const NotFoundPage = lazy(() => import('../pages/NotFoundPage'));
 const MainPage = lazy(() => import('../pages/MainPage'));
+const IntroPage = lazy(() => import('../pages/Intro/IntroPage'));
 const AboutPage = lazy(() => import('../pages/AboutPage'));
 const ReviewPage = lazy(() => import('../pages/ReviewPage'));
 const OrderHistorySection = lazy(() => import('../pages/MyPage/components/OrderHistorySection'));
@@ -48,6 +49,9 @@ export default function AppRouter() {
     <BrowserRouter basename="/bootrun-frontend">
       <Suspense fallback={<LoadingSpinner />}>
         <Routes>
+          {/* 그룹 0: 인트로 페이지 (루트) */}
+          <Route path={ROUTES.INTRO} element={<IntroPage />} />
+
           {/* 그룹 1: 비로그인 사용자만 접근 (로그인, 회원가입) */}
           <Route element={<PublicOnly />}>
             <Route element={<AuthLayout />}>

--- a/src/router/RouteConfig.ts
+++ b/src/router/RouteConfig.ts
@@ -1,5 +1,6 @@
 export const ROUTES = {
-    HOME: '/',                                  // 메인 페이지
+    INTRO: '/',                                 // 인트로 페이지
+    HOME: '/home',                              // 메인 페이지
     ABOUT: '/about',                            // 부트런 소개 페이지
     REVIEW: '/review',                          // 수강생 후기 페이지
     LOGIN: '/login',                            // 로그인 페이지


### PR DESCRIPTION
## 개요
- 서비스 최초 진입 시, 터미널 스타일의 인트로 페이지를 구현
- 루트 경로(/)를 인트로 페이지로 설정하고, 기존 메인 페이지는 /home으로 변경했습니다.

## 변경사항
- 인트로 페이지 추가 (src/pages/Intro/IntroPage.tsx)
- boot:run 텍스트 타이핑 애니메이션 구현
- OS 감지: 사용자 OS환경(Mac/Windows/모바일)에 따라 인트로 애니메이션 디자인 차별화
- 자동 리다이렉트: 애니메이션 종료 후 2.5초 뒤 메인 페이지(/home)로 자동 이동
- NotFoundPage, useAuthQueries, useDeleteAccountHandler: 홈으로 이동하는 로직을 ROUTES.HOME으로 일괄 업데이트

관련 이슈
Closes #202 

