### PR TITLE
[FIX] 개발자 소개 페이지 텍스트 변경 #234

### DIFF
--- a/src/pages/AboutTeam/components/HeroSection.tsx
+++ b/src/pages/AboutTeam/components/HeroSection.tsx
@@ -44,7 +44,7 @@ export default function HeroSection({
       )}
       <S.Title>
         <S.TitleText>
-          TEAM <S.ClickableI5>I5</S.ClickableI5>
+          TEAM&nbsp;<S.ClickableI5> I5</S.ClickableI5>
           <TooltipI5 show={showI5Tooltip} onToggle={() => setShowI5Tooltip(!showI5Tooltip)} />
         </S.TitleText>{' '}
         개발자 소개

--- a/src/pages/AboutTeam/components/TeamStatsSection.tsx
+++ b/src/pages/AboutTeam/components/TeamStatsSection.tsx
@@ -1,9 +1,9 @@
 import S from '../styles/TeamStatsSection.styled';
 
 const stats = [
-  { value: '700+', label: '총 커밋 수', delay: 0.1 },
-  { value: '3개월', label: '개발 기간', delay: 0.2 },
-  { value: '124,000+', label: '코드 라인', delay: 0.3 },
+  { value: '800+', label: '총 커밋 수', delay: 0.1 },
+  { value: '2개월', label: '개발 기간', delay: 0.2 },
+  { value: '41,000+', label: '서비스 코드 라인 수', delay: 0.3 },
   { value: '1,000번+', label: '칭찬 횟수', delay: 0.4 },
 ];
 

--- a/src/pages/AboutTeam/constants/developers.ts
+++ b/src/pages/AboutTeam/constants/developers.ts
@@ -34,8 +34,8 @@ export const developers: Developer[] = [
     description:
       '강의실 페이지, 학습 관리(진행률) 기능, 관리자(대시보드, 강의관리, 결제관리, 사용자관리) 페이지, 토스 결제 연동',
     github: 'https://github.com/chdev-kr',
-    story: '1) 제가 작업하면서 가장 많이 들은 노래는 어반자카파의 [Stay]입니다.',
-    story2: '2) 최근엔 메가커피 메가미숫커피에 빠졌습니다. 그리고 저는 오른손잡이입니다.',
+    story: '1) 부트런을 개발하며 주황색이 좋아졌습니다.',
+    story2: '2) 이스터에그 그림을 그렸습니다. 그리고 저는 오른손잡이입니다.',
     emojiImage: kirbyImage,
   },
   {
@@ -55,7 +55,7 @@ export const developers: Developer[] = [
     description:
       '환경 설정(env/config), 결제/관리자(사용자·결제·대시보드) API 개발, 로컬 서버 구축',
     github: 'https://github.com/hanbam03',
-    story: '1) 프로젝트 중간에 독감을 이겨냈습니다.',
+    story: '1) 프로젝트 중간에 몸살을 이겨냈습니다.',
     story2: '2) 팀원 5명 중에서 가장 밝은 에너지가 있는 사람입니다.',
     emojiImage: catImage,
   },

--- a/src/pages/AboutTeam/hooks/useTypingGame.ts
+++ b/src/pages/AboutTeam/hooks/useTypingGame.ts
@@ -19,7 +19,7 @@ export function useTypingGame(onSuccess: () => void) {
     setCurrentKey('B');
     setStartTime(Date.now());
     setGameMessage(
-      '프로젝트명을 입력하면 숨겨진 개발자들의 TMI가 나옵니다.(힌트: 부트런을 영어로 하면?)'
+      '프로젝트명을 입력하면 숨겨진 개발자들의 이야기가 나옵니다.(힌트: 부트런을 영어로 하면?)'
     );
   }, []);
 

--- a/src/pages/AboutTeam/pages/AboutTeamPage.tsx
+++ b/src/pages/AboutTeam/pages/AboutTeamPage.tsx
@@ -24,7 +24,7 @@ export default function AboutTeamPage() {
       '_blank',
       'noopener,noreferrer'
     );
-    alert('이 페이지를 개발한 개발자의 플레이리스트를 재생! 이스터에그를 다시 찾아보세요!');
+    alert('이 페이지를 제작한 개발자의 플레이리스트를 재생! 이스터에그를 다시 찾아보세요!');
   };
 
   const handleSpaghettiClick = () => {
@@ -37,7 +37,6 @@ export default function AboutTeamPage() {
   };
 
   const handleKirbyClick = () => {
-    window.open('https://www.youtube.com/watch?v=v9fzKdI3K_s', '_blank', 'noopener,noreferrer');
     alert('귀여운 커비 보고 힘내세요! 이스터에그를 다시 찾아보세요!');
   };
 


### PR DESCRIPTION
## 개요

- 개발자 소개 페이지 텍스트 변경

## 변경사항

- 이스터에그 힌트, 개발자 소개, 프로젝트 통계 등 텍스트 변경

## 참고사항
- 서비스 코드 수는 아래 명령어로 코드 수 확인하여 넣었음.(node_modules / build / .next 전부 제외)
- cloc . \  --exclude-dir=node_modules,.next,dist,build,.git,public

## 관련 이슈

Closes #234 
